### PR TITLE
Update to reflect new API requiring IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ Replace `<token>` with your actual PayNow token.
 
 To permanently set this, add `set paynow.token <token>` to your `server.cfg`
 
+### Setting Your Server IP
+
+To show your server's IP in the PayNow portal, you can set it using:
+
+```plaintext
+set paynow.ip <ip>
+```
+
+Replace `<ip>` with your actual server's IP.
+
+To permanently set this, add `set paynow.token <token>` to your `server.cfg`
+
 ### Adjusting Fetch Interval
 
 The default fetch interval is recommended for most servers, but you can adjust it to meet your specific needs by using the command `set paynow.interval <interval>`, with interval being in seconds.

--- a/classes/API.js
+++ b/classes/API.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 
 class PayNowAPI {
     constructor() {
-        this.version = '0.0.2';
+        this.version = '0.0.3';
         this.url = 'https://api.paynow.gg/v1/';
 
         this.token = GetConvar('paynow.token', '');
@@ -35,7 +35,12 @@ class PayNowAPI {
     }
 
     async serverLink() {
-        const result = await this.request('delivery/gameserver/link', 'POST', { platform: 'fivem', version: this.version, hostname: GetConvar('sv_hostname', 'Unknown') });
+        const result = await this.request('delivery/gameserver/link', 'POST', {
+            platform: 'fivem',
+            version: this.version,
+            hostname: GetConvar('sv_hostname', 'Unknown'),
+            ip: GetConvar('paynow.ip', '0.0.0.0')
+        });
 
         if (!result) return;
 
@@ -164,6 +169,8 @@ class PayNowAPI {
             return result.data;
         } catch (error) {
             this.log(`Request failed: ${error.message}`);
+
+            console.error(error.response?.data || error);
 
             return null;
         }


### PR DESCRIPTION
The API now requires the `ip` field when linking a server. This has been updated to pull it from the user's config (`paynow.ip`) or default to `0.0.0.0`.