### PR TITLE
Add passing player's source from their Steam ID

### DIFF
--- a/util/decimalToHex.js
+++ b/util/decimalToHex.js
@@ -1,0 +1,15 @@
+const decimalTohex = (decimal) => {
+    try {
+        const bigInt = BigInt(decimal);
+
+        const hexValue = bigInt.toString(16);
+
+        return hexValue;
+    } catch (error) {
+        console.error('decimalToHex error:', error);
+
+        return null;
+    }
+}
+
+module.exports = decimalTohex;


### PR DESCRIPTION
This allows people to put `{player.source_from:{customer.steam.id}}` in their command. This will allow people to use a player's source to run commands.